### PR TITLE
Add optional return_attention param to model

### DIFF
--- a/deepmoji/attlayer.py
+++ b/deepmoji/attlayer.py
@@ -6,7 +6,6 @@ from os.path import dirname
 sys.path.append(dirname(dirname(__file__)))
 from keras import initializers
 from keras.engine import InputSpec, Layer
-from keras.layers.merge import concatenate
 from keras import backend as K
 
 class AttentionWeightedAverage(Layer):

--- a/deepmoji/attlayer.py
+++ b/deepmoji/attlayer.py
@@ -49,7 +49,7 @@ class AttentionWeightedAverage(Layer):
         weighted_input = x * K.expand_dims(att_weights)
         result = K.sum(weighted_input, axis=1)
         if self.return_attention:
-            return concatenate([result, att_weights])
+            return [result, att_weights]
         return result
 
     def get_output_shape_for(self, input_shape):
@@ -58,7 +58,7 @@ class AttentionWeightedAverage(Layer):
     def compute_output_shape(self, input_shape):
         output_len = input_shape[2]
         if self.return_attention:
-            output_len += input_shape[1]
+            return [(input_shape[0], output_len), (input_shape[0], input_shape[1])]
         return (input_shape[0], output_len)
 
     def compute_mask(self, input, input_mask=None):

--- a/deepmoji/model_def.py
+++ b/deepmoji/model_def.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 
 from keras.models import Model, Sequential
 from keras.layers.merge import concatenate
-from keras.layers import Input, Bidirectional, Embedding, Dense, Dropout, SpatialDropout1D, LSTM, Activation, Lambda
+from keras.layers import Input, Bidirectional, Embedding, Dense, Dropout, SpatialDropout1D, LSTM, Activation
 from keras.regularizers import L1L2
 from attlayer import AttentionWeightedAverage
 from global_variables import NB_TOKENS, NB_EMOJI_CLASSES
@@ -44,6 +44,8 @@ def deepmoji_emojis(maxlen, weight_path, return_attention=False):
     # Arguments:
         maxlen: Maximum length of a sentence (given in tokens).
         weight_path: Path to model weights to be loaded.
+        return_attention: If true, output will be weight of each input token
+            used for the prediction
 
     # Returns:
         Pretrained model for encoding text into feature vectors.

--- a/tests/test_finetuning.py
+++ b/tests/test_finetuning.py
@@ -74,6 +74,24 @@ def test_deepmoji_transfer_extend_embedding():
     assert embedding_layer.input_dim == NB_TOKENS + extend_with
 
 
+def test_deepmoji_return_attention():
+    # test the output of the normal model
+    model = deepmoji_emojis(maxlen=30, weight_path=PRETRAINED_PATH)
+    # check correct number of outputs
+    assert 1 == len(model.outputs)
+    # check model outputs come from correct layers
+    assert [['softmax', 0, 0]] == model.get_config()['output_layers']
+    # ensure that output shapes are correct (assume a 5-example batch of 30-timesteps)
+    input_shape = (5, 30, 2304)
+    assert (5, 2304) == model.layers[6].compute_output_shape(input_shape)
+
+    # repeat above described tests when returning attention weights
+    model = deepmoji_emojis(maxlen=30, weight_path=PRETRAINED_PATH, return_attention=True)
+    assert 2 == len(model.outputs)
+    assert [['softmax', 0, 0], ['attlayer', 0, 1]] == model.get_config()['output_layers']
+    assert [(5, 2304), (5, 30)] == model.layers[6].compute_output_shape(input_shape)
+
+
 def test_relabel():
     """ relabel() works with multi-class labels.
     """


### PR DESCRIPTION
This PR adds the ability to return attention mechanism weights from the AttentionWeightedAverage layer and the full DeepMoji model. In the latter case, the weights are exposed as another model output for easy integration.

Closes #4.