### PR TITLE
imdb example: fix deprecated warnings

### DIFF
--- a/examples/imdb_from_scratch.py
+++ b/examples/imdb_from_scratch.py
@@ -18,7 +18,7 @@ maxlen = 80
 batch_size = 32
 
 print('Loading data...')
-(X_train, y_train), (X_test, y_test) = imdb.load_data(nb_words=nb_tokens)
+(X_train, y_train), (X_test, y_test) = imdb.load_data(num_words=nb_tokens)
 print(len(X_train), 'train sequences')
 print(len(X_test), 'test sequences')
 
@@ -37,7 +37,7 @@ model.compile(loss='binary_crossentropy',
               metrics=['accuracy'])
 
 print('Train...')
-model.fit(X_train, y_train, batch_size=batch_size, nb_epoch=15,
+model.fit(X_train, y_train, batch_size=batch_size, epochs=15,
           validation_data=(X_test, y_test))
 score, acc = model.evaluate(X_test, y_test, batch_size=batch_size)
 print('Test score:', score)


### PR DESCRIPTION
Hi,

this PR fixes some deprecated warnings:

```bash
/home/stefan/.local/lib/python2.7/site-packages/keras/datasets/imdb.py:45: UserWarning: The `nb_words` argument in `load_data` has been renamed `num_words`.
  warnings.warn('The `nb_words` argument in `load_data` '

imdb_from_scratch.py:41: UserWarning: The `nb_epoch` argument in `fit` has been renamed `epochs`.
  validation_data=(X_test, y_test))
```

For more information see [Keras 2.0 release notes](https://github.com/fchollet/keras/releases/tag/2.0.0).