### PR TITLE
added multilabel support by adding a sigmoid option

### DIFF
--- a/deepmoji/finetuning.py
+++ b/deepmoji/finetuning.py
@@ -415,10 +415,10 @@ def tune_trainable(model, nb_classes, train, val, test, epoch_size,
     X_val, y_val = val
     X_test, y_test = test
 
-    # if nb_classes > 2:
-        # y_train = to_categorical(y_train)
-        # y_val = to_categorical(y_val)
-        # y_test = to_categorical(y_test)
+    if nb_classes > 2 and y_train.shape[1] > 1:
+        y_train = to_categorical(y_train)
+        y_val = to_categorical(y_val)
+        y_test = to_categorical(y_test)
 
     if verbose:
         print("Trainable weights: {}".format(model.trainable_weights))
@@ -523,10 +523,10 @@ def chain_thaw(model, nb_classes, train, val, test, batch_size,
     X_val, y_val = val
     X_test, y_test = test
 
-    # if nb_classes > 2:
-    #     y_train = to_categorical(y_train)
-    #     y_val = to_categorical(y_val)
-    #     y_test = to_categorical(y_test)
+    if nb_classes > 2 and y_train.shape[1] > 1:
+        y_train = to_categorical(y_train)
+        y_val = to_categorical(y_val)
+        y_test = to_categorical(y_test)
 
     if verbose:
         print('Training..')

--- a/deepmoji/finetuning.py
+++ b/deepmoji/finetuning.py
@@ -415,7 +415,7 @@ def tune_trainable(model, nb_classes, train, val, test, epoch_size,
     X_val, y_val = val
     X_test, y_test = test
 
-    if nb_classes > 2 and y_train.shape[1] > 1:
+    if nb_classes > 2 and (len(y_train.shape) == 1 or y_train.shape[1] <= 1):
         y_train = to_categorical(y_train)
         y_val = to_categorical(y_val)
         y_test = to_categorical(y_test)
@@ -523,7 +523,7 @@ def chain_thaw(model, nb_classes, train, val, test, batch_size,
     X_val, y_val = val
     X_test, y_test = test
 
-    if nb_classes > 2 and y_train.shape[1] > 1:
+    if nb_classes > 2 and (len(y_train.shape) == 1 or y_train.shape[1] <= 1):
         y_train = to_categorical(y_train)
         y_val = to_categorical(y_val)
         y_test = to_categorical(y_test)

--- a/deepmoji/finetuning.py
+++ b/deepmoji/finetuning.py
@@ -415,10 +415,10 @@ def tune_trainable(model, nb_classes, train, val, test, epoch_size,
     X_val, y_val = val
     X_test, y_test = test
 
-    if nb_classes > 2:
-        y_train = to_categorical(y_train)
-        y_val = to_categorical(y_val)
-        y_test = to_categorical(y_test)
+    # if nb_classes > 2:
+        # y_train = to_categorical(y_train)
+        # y_val = to_categorical(y_val)
+        # y_test = to_categorical(y_test)
 
     if verbose:
         print("Trainable weights: {}".format(model.trainable_weights))
@@ -523,10 +523,10 @@ def chain_thaw(model, nb_classes, train, val, test, batch_size,
     X_val, y_val = val
     X_test, y_test = test
 
-    if nb_classes > 2:
-        y_train = to_categorical(y_train)
-        y_val = to_categorical(y_val)
-        y_test = to_categorical(y_test)
+    # if nb_classes > 2:
+    #     y_train = to_categorical(y_train)
+    #     y_val = to_categorical(y_val)
+    #     y_test = to_categorical(y_test)
 
     if verbose:
         print('Training..')

--- a/deepmoji/model_def.py
+++ b/deepmoji/model_def.py
@@ -100,7 +100,7 @@ def deepmoji_transfer(nb_classes, maxlen, weight_path=None, extend_embedding=0,
     return model
 
 
-def deepmoji_architecture(nb_classes, nb_tokens, maxlen, feature_output=False, embed_dropout_rate=0, final_dropout_rate=0, embed_l2=1E-6, return_attention=False):
+def deepmoji_architecture(nb_classes, nb_tokens, maxlen, feature_output=False, embed_dropout_rate=0, final_dropout_rate=0, embed_l2=1E-6, return_attention=False, multilabel=False):
     """
     Returns the DeepMoji architecture uninitialized and
     without using the pretrained model weights.
@@ -158,7 +158,7 @@ def deepmoji_architecture(nb_classes, nb_tokens, maxlen, feature_output=False, e
             x = Dropout(final_dropout_rate)(x)
 
         if nb_classes > 2:
-            outputs = [Dense(nb_classes, activation='softmax', name='softmax')(x)]
+            outputs = [Dense(nb_classes, activation='sigmoid' if multilabel else 'softmax', name='softmax')(x)]
         else:
             outputs = [Dense(1, activation='sigmoid', name='softmax')(x)]
     else:

--- a/deepmoji/model_def.py
+++ b/deepmoji/model_def.py
@@ -61,7 +61,7 @@ def deepmoji_emojis(maxlen, weight_path, return_attention=False):
 
 def deepmoji_transfer(nb_classes, maxlen, weight_path=None, extend_embedding=0,
                       embed_dropout_rate=0.25, final_dropout_rate=0.5,
-                      embed_l2=1E-6):
+                      embed_l2=1E-6, multilabel=False):
     """ Loads the pretrained DeepMoji model for finetuning/transfer learning.
         Does not load weights for the softmax layer.
 
@@ -91,7 +91,8 @@ def deepmoji_transfer(nb_classes, maxlen, weight_path=None, extend_embedding=0,
     model = deepmoji_architecture(nb_classes=nb_classes,
                                   nb_tokens=NB_TOKENS + extend_embedding,
                                   maxlen=maxlen, embed_dropout_rate=embed_dropout_rate,
-                                  final_dropout_rate=final_dropout_rate, embed_l2=embed_l2)
+                                  final_dropout_rate=final_dropout_rate, embed_l2=embed_l2,
+                                  multilabel=multilabel)
 
     if weight_path is not None:
         load_specific_weights(model, weight_path,


### PR DESCRIPTION
This adds multi-label support in the `softmax` layer. The only difference is it returns a multi-class `Sigmoid` layer instead of `Softmax`.

```
deepmoji_architecture(..., multilabel=True)
deepmoji_transfer(..., multilabel=True)
```